### PR TITLE
DE-873 | deploy snowflake workflow

### DIFF
--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -47,10 +47,10 @@ jobs:
           snow sql -x -q 'CREATE OR REPLACE FUNCTION TERAKEET.COMMON.NORMALIZE_URL_TEMP("URL" VARCHAR)
                         RETURNS VARCHAR
                         LANGUAGE PYTHON
-                        RUNTIME_VERSION = ''\''3.11'\''
-                        HANDLER = '\''normalize'\''
+                        RUNTIME_VERSION = "3.11"
+                        HANDLER = "normalize"
                         ARTIFACT_REPOSITORY = snowflake.snowpark.pypi_shared_repository
-                        PACKAGES = ('\''tk-normalizer'\''')
+                        PACKAGES = ("tk-normalizer")
                         AS
                         $$
                         from tk_normalizer import TkNormalizer, InvalidUrlException

--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -1,10 +1,8 @@
 name: Deploy Normalizer to Snowflake
 
 on:
-    # workflow_run:
-    #     workflows: [deploy_to_pypi]
-    #     types: [completed]
-
+    push:
+        branches: [feature/snowflake-deploy]
 jobs:
   update-snowflake-udf:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -44,13 +44,13 @@ jobs:
             SNOWFLAKE_PRIVATE_KEY_RAW: ${{ env.SNOWFLAKE_PRIVATE_KEY }}
 
         run: |
-          snow sql -x -q "CREATE OR REPLACE FUNCTION TERAKEET.COMMON.NORMALIZE_URL_TEMP("URL" VARCHAR)
+          snow sql -x -q 'CREATE OR REPLACE FUNCTION TERAKEET.COMMON.NORMALIZE_URL_TEMP("URL" VARCHAR)
                         RETURNS VARCHAR
                         LANGUAGE PYTHON
-                        RUNTIME_VERSION = '3.11'
-                        HANDLER = 'normalize'
+                        RUNTIME_VERSION = ''\''3.11'\''
+                        HANDLER = '\''normalize'\''
                         ARTIFACT_REPOSITORY = snowflake.snowpark.pypi_shared_repository
-                        PACKAGES = ('tk-normalizer')
+                        PACKAGES = ('\''tk-normalizer'\''')
                         AS
                         $$
                         from tk_normalizer import TkNormalizer, InvalidUrlException
@@ -62,4 +62,4 @@ jobs:
                                 return str(normalized_value)
                             except InvalidUrlException:
                                 return None
-                        $$;"
+                        $$;'

--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -1,0 +1,62 @@
+name: Deploy Normalizer to Snowflake
+
+on:
+    release:
+        types: [created]
+
+    workflow_dispatch:
+        inputs:
+        version_type:
+            description: 'Please input major or minor'
+            required: true
+            type: choice
+            default: minor
+            options:
+            - major
+            - minor
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      SNOWFLAKE_ACCOUNT: "${{ secrets.SNOWFLAKE_ACCOUNT }}"
+      SNOWFLAKE_USERNAME: "SERVICE_GITHUB_USER"
+      SNOWFLAKE_PRIVATE_KEY: "${{ secrets.SNOWFLAKE_PRIVATE_KEY }}"
+      SNOWSQL_ROLE: "DATA_ENGINEER"
+      SNOWSQL_WAREHOUSE: "GITHUB_WH"
+
+    steps:
+      - uses: actions/checkout@v3
+
+        # Snowflake CLI installation
+      - uses: snowflakedb/snowflake-cli-action@v1.5
+
+          # Use the CLI
+      - name: Execute Snowflake CLI command
+        env:
+            SNOWFLAKE_AUTHENTICATOR: SNOWFLAKE_JWT
+            SNOWFLAKE_USER: ${{ env.SNOWFLAKE_USERNAME }}
+            SNOWFLAKE_ACCOUNT: ${{ env.SNOWFLAKE_ACCOUNT }}
+            SNOWFLAKE_PRIVATE_KEY_RAW: ${{ env.SNOWFLAKE_PRIVATE_KEY }}
+
+        run: |
+          snow sql -x -q "CREATE OR REPLACE FUNCTION TERAKEET.COMMON.NORMALIZE_URL_TEMP("URL" VARCHAR)
+                            RETURNS VARCHAR
+                            LANGUAGE PYTHON
+                            RUNTIME_VERSION = '3.11'
+                            HANDLER = 'normalize'
+                            ARTIFACT_REPOSITORY = snowflake.snowpark.pypi_shared_repository
+                            PACKAGES = ('tk-normalizer')
+                            AS
+                            $$
+                            from tk_normalizer import TkNormalizer, InvalidUrlException
+                            def normalize(url):
+                                if url is None:
+                                    return None
+                                try:
+                                    normalized_value = TkNormalizer(url)
+                                    return str(normalized_value)
+                                except InvalidUrlException:
+                                    return None
+                            $$;"

--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -18,21 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set env
-        id: get_env
-        run: echo "short_ref=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-
-      - name: Determine database
-        shell: bash
-        env:
-          BRANCH: ${{ steps.get_env.outputs.short_ref }}
-        run: |
-          if [ ${BRANCH} == "main" ]; then
-            echo "SNOWFLAKE_DATABASE=TERAKEET" >> $GITHUB_ENV
-          else
-            echo "SNOWFLAKE_DATABASE=TERAKEET_DEV" >> $GITHUB_ENV
-          fi
-
         # Snowflake CLI installation
       - uses: snowflakedb/snowflake-cli-action@v1.5
 
@@ -45,7 +30,7 @@ jobs:
             SNOWFLAKE_PRIVATE_KEY_RAW: ${{ env.SNOWFLAKE_PRIVATE_KEY }}
 
         run: |
-          snow sql -x -q 'CREATE OR REPLACE FUNCTION TERAKEET.COMMON.NORMALIZE_URL_TEMP("URL" VARCHAR)
+          snow sql -x -q 'CREATE OR REPLACE FUNCTION TERAKEET.COMMON.NORMALIZE_URL("URL" VARCHAR)
                         RETURNS VARCHAR
                         LANGUAGE PYTHON
                         RUNTIME_VERSION = "3.11"

--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -1,8 +1,9 @@
 name: Update Snowflake Normalizer UDF Definition
 
 on:
-    push:
-        branches: [feature/snowflake-deploy]
+    workflow_run:
+        workflows: [deploy_to_pypi]
+        types: [completed]
 jobs:
   update-snowflake-udf:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -1,22 +1,12 @@
 name: Deploy Normalizer to Snowflake
 
 on:
-    release:
-        types: [created]
-
-    workflow_dispatch:
-        inputs:
-        version_type:
-            description: 'Please input major or minor'
-            required: true
-            type: choice
-            default: minor
-            options:
-            - major
-            - minor
+    # workflow_run:
+    #     workflows: [deploy_to_pypi]
+    #     types: [completed]
 
 jobs:
-  deploy:
+  update-snowflake-udf:
     runs-on: ubuntu-latest
 
     env:
@@ -28,6 +18,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set env
+        id: get_env
+        run: echo "short_ref=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
+      - name: Determine database
+        shell: bash
+        env:
+          BRANCH: ${{ steps.get_env.outputs.short_ref }}
+        run: |
+          if [ ${BRANCH} == "main" ]; then
+            echo "SNOWFLAKE_DATABASE=TERAKEET" >> $GITHUB_ENV
+          else
+            echo "SNOWFLAKE_DATABASE=TERAKEET_DEV" >> $GITHUB_ENV
+          fi
 
         # Snowflake CLI installation
       - uses: snowflakedb/snowflake-cli-action@v1.5
@@ -42,21 +47,21 @@ jobs:
 
         run: |
           snow sql -x -q "CREATE OR REPLACE FUNCTION TERAKEET.COMMON.NORMALIZE_URL_TEMP("URL" VARCHAR)
-                            RETURNS VARCHAR
-                            LANGUAGE PYTHON
-                            RUNTIME_VERSION = '3.11'
-                            HANDLER = 'normalize'
-                            ARTIFACT_REPOSITORY = snowflake.snowpark.pypi_shared_repository
-                            PACKAGES = ('tk-normalizer')
-                            AS
-                            $$
-                            from tk_normalizer import TkNormalizer, InvalidUrlException
-                            def normalize(url):
-                                if url is None:
-                                    return None
-                                try:
-                                    normalized_value = TkNormalizer(url)
-                                    return str(normalized_value)
-                                except InvalidUrlException:
-                                    return None
-                            $$;"
+                        RETURNS VARCHAR
+                        LANGUAGE PYTHON
+                        RUNTIME_VERSION = '3.11'
+                        HANDLER = 'normalize'
+                        ARTIFACT_REPOSITORY = snowflake.snowpark.pypi_shared_repository
+                        PACKAGES = ('tk-normalizer')
+                        AS
+                        $$
+                        from tk_normalizer import TkNormalizer, InvalidUrlException
+                        def normalize(url):
+                            if url is None:
+                                return None
+                            try:
+                                normalized_value = TkNormalizer(url)
+                                return str(normalized_value)
+                            except InvalidUrlException:
+                                return None
+                        $$;"

--- a/.github/workflows/deploy_to_snowflake.yml
+++ b/.github/workflows/deploy_to_snowflake.yml
@@ -1,4 +1,4 @@
-name: Deploy Normalizer to Snowflake
+name: Update Snowflake Normalizer UDF Definition
 
 on:
     push:
@@ -48,9 +48,9 @@ jobs:
                         RETURNS VARCHAR
                         LANGUAGE PYTHON
                         RUNTIME_VERSION = "3.11"
-                        HANDLER = "normalize"
+                        HANDLER = '\''normalize'\''
                         ARTIFACT_REPOSITORY = snowflake.snowpark.pypi_shared_repository
-                        PACKAGES = ("tk-normalizer")
+                        PACKAGES = ('\''tk-normalizer'\'')
                         AS
                         $$
                         from tk_normalizer import TkNormalizer, InvalidUrlException

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ We have a [workflow](.github/workflows/deploy_to_pypi.yml) set up to deploy to o
 
 If you have questions or concerns reach out.
 
+## Deploying to Snowflake -- UDF Update
+The normalizer implementaiton in snowflake is defined at [TERAKEET.COMMON.NORMALIZE_URL](https://app.snowflake.com/rbvgkpe/fhb30323/#/data/databases/TERAKEET/schemas/COMMON/user-function/NORMALIZE_URL(VARCHAR)).
+Once PYPI has been deployed, another [workflow](.github/workflows/deploy_to_snowflake.yml) will run and update the UDF in Snowflake. That UDF needs the new version of PYPI and will just override the current function. This happens instantly after PYPI has been deployed.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ We have a [workflow](.github/workflows/deploy_to_pypi.yml) set up to deploy to o
 6. After creating the release you should see a workflow get triggered, this will deploy the updated version to pypi
 7. If you want to see check the pypi package page after the workflow completes running
 
+> NOTE: DO NOT change the name of the workflow file. If you do the deployment will not work unless we update the configuration in PYPI under trusted publishers
+
 If you have questions or concerns reach out.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -193,6 +193,24 @@ pytest --cov=tk_normalizer --cov-report=html
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+## Deploying to PYPI
+
+We have a [workflow](.github/workflows/deploy_to_pypi.yml) set up to deploy to our [PYPI package](https://pypi.org/project/tk-normalizer/) when a release is created. Here is how you can do that:
+1. Cut a PR for your change
+2. Make sure you increment your version number in the [pyproject.toml](pyproject.toml) file in your changes
+3. After approval, merge changes to main branch
+4. Cut a new release in GitHub
+    - this can be found on the right hand side of the screen when you are at the repo's home page
+    - you should see the current release
+5. For consistency in the release:
+    - create a new tag that matches the version number you changed earlier
+    - add a title with a brief description of the changes
+    - add a small description or link to JIRA tickets for updates
+6. After creating the release you should see a workflow get triggered, this will deploy the updated version to pypi
+7. If you want to see check the pypi package page after the workflow completes running
+
+If you have questions or concerns reach out.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.


### PR DESCRIPTION
Turns out the UDF needs a refresh when we push to pypi. This work flow will run after the pypi publish workflow. That update will need to complete prior to this running. This workflow just redefines the UDF with the same definition with the new pypi package updates.